### PR TITLE
correção de teste unitário. mock de DebitoCobradoNaoParceladoTO nao e…

### DIFF
--- a/src/test/java/br/gov/batch/servicos/faturamento/arquivo/ArquivoTextoTipo04Test.java
+++ b/src/test/java/br/gov/batch/servicos/faturamento/arquivo/ArquivoTextoTipo04Test.java
@@ -64,6 +64,7 @@ public class ArquivoTextoTipo04Test {
 		debitoCobrado.setTotalPrestacao(Short.valueOf("10"));
 		debitoCobrado.setNumeroPrestacaoDebito(Short.valueOf("1"));
 		debitoCobrado.setDebitoTipo(debitoTipo.getId());
+		debitoCobrado.setDescricaoTipoDebito("CONSUMO DE AGUA");
 
 		debitosCobrados = new ArrayList<DebitoCobradoNaoParceladoTO>();
 		debitosCobrados.add(debitoCobrado);


### PR DESCRIPTION
…stava setando um atributo necessário para rodar o teste.